### PR TITLE
Delete changeTurns.js

### DIFF
--- a/imports/src/helpers/changeTurns.js
+++ b/imports/src/helpers/changeTurns.js
@@ -1,3 +1,0 @@
-export function changeTurns(turn) {
-  return turn === "black" ? "white" : "black";
-}


### PR DESCRIPTION
This branch has only one commit which deletes changeTurns.js because it
was functionally equivalent to invertColor.js and therefore unnecessary
clutter.