### PR TITLE
Add functionality: turn baseline pawn into figure

### DIFF
--- a/imports/src/App.css
+++ b/imports/src/App.css
@@ -1,6 +1,12 @@
 body {
   font-size: 1.6em;
 }
+.grey {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 3%;
+  background-color: grey;
+}
 @media only screen and (orientation: portrait) {
   .AppContainer {
     padding-top: 10%;

--- a/imports/src/tileMarkers/pawnMovement.js
+++ b/imports/src/tileMarkers/pawnMovement.js
@@ -33,7 +33,12 @@ function getPawnRowTransformations(row, color) {
 function diagonalPawnCaptures(board, row, col, color, mark) {
   let rowChange = color === "white" ? -1 : 1;
   [-1, 1].forEach(y => {
-    if (0 <= col + y && col + y <= 7) {
+    if (
+      0 <= col + y &&
+      col + y <= 7 &&
+      row + rowChange <= 7 &&
+      0 <= row + rowChange
+    ) {
       let tile = board[row + rowChange][col + y];
       if (tile.figure !== "noFigure" && tile.figure.color !== color) {
         if (mark === "valid") {


### PR DESCRIPTION
This is the only commit in this branch. The branch adds a core
functionality to the game of chess. It allows players to change their
pawn into a figure of their choice once it reaches the enemies baseline.
The game will pause and not accept any more inputs until the choice has
been done. The move is affected by the undo just like all the other
moves. Upon undoing the newly created piece vanishes and makes place for
whatever came before it - be it an empty tile or a captured enemy piece.